### PR TITLE
Fixed 404 error on "sprint report video" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Together we want to work on the goal of **Increased (scientific) literacy in our
 
 <BR>
 
-**To stay updated about WorldBrain's progress**, check out **[our 2-3 minute sprint report video](www.worldbrain.io/2016/blog/)**, we publish every 2nd Wednesday or subscribe to our **[developer mailing list](https://groups.google.com/forum/#!forum/worldbrain-dev-mailing-list)**.
+**To stay updated about WorldBrain's progress**, check out **[our 2-3 minute sprint report video](http://www.worldbrain.io/category/sprint-reports/)**, we publish every 2nd Wednesday or subscribe to our **[developer mailing list](https://groups.google.com/forum/#!forum/worldbrain-dev-mailing-list)**.
 
 
 #### Latest


### PR DESCRIPTION
The "check out our 2-3 minute sprint report video" was incorrectly linked and produced a 404 error. I found the intended page and replaced it in this proposed file change. :)